### PR TITLE
appdata: add vcs-browser and translate support

### DIFF
--- a/data/com.vixalien.decibels.metainfo.xml.in.in
+++ b/data/com.vixalien.decibels.metainfo.xml.in.in
@@ -78,8 +78,10 @@
   </releases>
   <launchable type="desktop-id">@app-id@.desktop</launchable>
   <url type="homepage">https://github.com/vixalien/decibels</url>
-	<url type="bugtracker">https://github.com/vixalien/decibels/issues</url>
+  <url type="bugtracker">https://github.com/vixalien/decibels/issues</url>
   <url type="donation">https://www.buymeacoffee.com/vixalien</url>
+  <url type="translate">https://github.com/vixalien/decibels/tree/main/po</url>
+  <url type="vcs-browser">https://github.com/vixalien/decibels</url>
   <translation type="gettext">@gettext-package@</translation>
   <custom>
 		<value key="Purism::form_factor">workstation</value>


### PR DESCRIPTION
These urls are visible on Flathub and GNOME Control Center.

More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-url