### PR TITLE
Normalize the waveform

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           flatpak --system install -y --noninteractive flathub org.freedesktop.Sdk.Extension.node18/${{ matrix.arch }}/23.08
           flatpak --system install -y --noninteractive flathub org.freedesktop.Sdk.Extension.typescript/${{ matrix.arch }}/23.08
+          flatpak --system install -y --noninteractive flathub org.freedesktop.Sdk.Extension.rust-stable/${{ matrix.arch }}/23.08
       - uses: flatpak/flatpak-github-actions/flatpak-builder@v4
         with:
           bundle: com.vixalien.decibels.nightly.flatpak

--- a/build-aux/flatpak/com.vixalien.decibels.json
+++ b/build-aux/flatpak/com.vixalien.decibels.json
@@ -5,13 +5,17 @@
   "sdk": "org.gnome.Sdk",
   "sdk-extensions": [
     "org.freedesktop.Sdk.Extension.node18",
-    "org.freedesktop.Sdk.Extension.typescript"
+    "org.freedesktop.Sdk.Extension.typescript",
+    "org.freedesktop.Sdk.Extension.rust-stable"
   ],
   "tags": [
     "nightly"
   ],
   "build-options": {
-    "append-path": "/usr/lib/sdk/node18/bin:/usr/lib/sdk/typescript/bin"
+    "env": {
+      "CARGO_HOME": "/run/build/cargo-c/cargo"
+    },
+    "append-path": "/usr/lib/sdk/node18/bin:/usr/lib/sdk/typescript/bin:/usr/lib/sdk/rust-stable/bin"
   },
   "command": "com.vixalien.decibelsDevel",
   "finish-args": [
@@ -37,6 +41,43 @@
     "*.a"
   ],
   "modules": [
+    {
+      "name": "cargo-c",
+      "buildsystem": "simple",
+      "build-commands": [
+        "cargo install cargo-c --root /app"
+      ],
+      "build-options": {
+        "build-args": [
+          "--share=network"
+        ]
+      },
+      "cleanup": [
+        "*"
+      ]
+    },
+    {
+      "name": "gst-plugins-rs",
+      "buildsystem": "simple",
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs",
+          "branch": "0.11"
+        }
+      ],
+      "build-options": {
+        "build-args": [
+          "--share=network"
+        ],
+        "env": {
+          "CARGO_NET_GIT_FETCH_WITH_CLI": "true"
+        }
+      },
+      "build-commands": [
+        "cargo cinstall -p gst-plugin-audiofx --prefix=/app"
+      ]
+    },
     {
       "name": "decibels",
       "buildsystem": "meson",

--- a/src/com.vixalien.decibels.src.gresource.xml.in
+++ b/src/com.vixalien.decibels.src.gresource.xml.in
@@ -11,6 +11,7 @@
     <file>playback-rate-button.js</file>
     <file>player.js</file>
     <file>stream.js</file>
+    <file>util.js</file>
     <file>waveform.js</file>
     <file>window.js</file>
   </gresource>

--- a/src/meson.build
+++ b/src/meson.build
@@ -11,6 +11,7 @@ sources = [
   'playback-rate-button.ts',
   'player.ts',
   'stream.ts',
+  'util.js',
   'waveform.ts',
   'window.ts',
 ]

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -272,6 +272,12 @@ export class APMediaStream extends Gtk.MediaStream {
           return;
       }
 
+      this.peaks_generator.restart();
+      this.peaks_generator.generate_peaks_async(
+        this._play.uri,
+        info.get_duration(),
+      );
+
       // try to generate an initial peaks array
       if (this.peaks_generator.peaks.length === 0) {
         const duration = info.get_duration();
@@ -647,8 +653,6 @@ export class APMediaStream extends Gtk.MediaStream {
     this.discoverer.stop();
     this.discoverer.start();
 
-    this.peaks_generator.restart();
-
     if (this.prepared) {
       this.stream_unprepared();
     }
@@ -661,7 +665,6 @@ export class APMediaStream extends Gtk.MediaStream {
     this._play.uri = uri;
 
     this.discoverer.discover_uri_async(uri);
-    this.peaks_generator.generate_peaks_async(uri);
   }
 
   get_uri() {
@@ -677,7 +680,6 @@ export class APMediaStream extends Gtk.MediaStream {
     this._play.uri = uri;
 
     this.discoverer.discover_uri_async(uri);
-    this.peaks_generator.generate_peaks_async(uri);
   }
 
   stop() {

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,315 @@
+const root = globalThis;
+
+/**
+ * Checks if `value` is the
+ * [language type](http://www.ecma-international.org/ecma-262/7.0/#sec-ecmascript-language-types)
+ * of `Object`. (e.g. arrays, functions, objects, regexes, `new Number(0)`, and `new String('')`)
+ *
+ * @since 0.1.0
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is an object, else `false`.
+ * @example
+ *
+ * isObject({})
+ * // => true
+ *
+ * isObject([1, 2, 3])
+ * // => true
+ *
+ * isObject(Function)
+ * // => true
+ *
+ * isObject(null)
+ * // => false
+ */
+export function isObject(value) {
+  const type = typeof value;
+  return value != null && (type === "object" || type === "function");
+}
+
+/**
+ * Creates a debounced function that delays invoking `func` until after `wait`
+ * milliseconds have elapsed since the last time the debounced function was
+ * invoked, or until the next browser frame is drawn. The debounced function
+ * comes with a `cancel` method to cancel delayed `func` invocations and a
+ * `flush` method to immediately invoke them. Provide `options` to indicate
+ * whether `func` should be invoked on the leading and/or trailing edge of the
+ * `wait` timeout. The `func` is invoked with the last arguments provided to the
+ * debounced function. Subsequent calls to the debounced function return the
+ * result of the last `func` invocation.
+ *
+ * **Note:** If `leading` and `trailing` options are `true`, `func` is
+ * invoked on the trailing edge of the timeout only if the debounced function
+ * is invoked more than once during the `wait` timeout.
+ *
+ * If `wait` is `0` and `leading` is `false`, `func` invocation is deferred
+ * until the next tick, similar to `setTimeout` with a timeout of `0`.
+ *
+ * If `wait` is omitted in an environment with `requestAnimationFrame`, `func`
+ * invocation will be deferred until the next frame is drawn (typically about
+ * 16ms).
+ *
+ * See [David Corbacho's article](https://css-tricks.com/debouncing-throttling-explained-examples/)
+ * for details over the differences between `debounce` and `throttle`.
+ *
+ * @since 0.1.0
+ * @category Function
+ * @param {Function} func The function to debounce.
+ * @param {number} [wait=0]
+ *  The number of milliseconds to delay; if omitted, `requestAnimationFrame` is
+ *  used (if available).
+ * @param {Object} [options={}] The options object.
+ * @param {boolean} [options.leading=false]
+ *  Specify invoking on the leading edge of the timeout.
+ * @param {number} [options.maxWait]
+ *  The maximum time `func` is allowed to be delayed before it's invoked.
+ * @param {boolean} [options.trailing=true]
+ *  Specify invoking on the trailing edge of the timeout.
+ * @returns {Function} Returns the new debounced function.
+ * @example
+ *
+ * // Avoid costly calculations while the window size is in flux.
+ * jQuery(window).on('resize', debounce(calculateLayout, 150))
+ *
+ * // Invoke `sendMail` when clicked, debouncing subsequent calls.
+ * jQuery(element).on('click', debounce(sendMail, 300, {
+ *   'leading': true,
+ *   'trailing': false
+ * }))
+ *
+ * // Ensure `batchLog` is invoked once after 1 second of debounced calls.
+ * const debounced = debounce(batchLog, 250, { 'maxWait': 1000 })
+ * const source = new EventSource('/stream')
+ * jQuery(source).on('message', debounced)
+ *
+ * // Cancel the trailing debounced invocation.
+ * jQuery(window).on('popstate', debounced.cancel)
+ *
+ * // Check for pending invocations.
+ * const status = debounced.pending() ? "Pending..." : "Ready"
+ */
+export function debounce(func, wait, options) {
+  let lastArgs;
+  let lastThis;
+  let maxWait;
+  let result;
+  let timerId;
+  let lastCallTime;
+  let lastInvokeTime = 0;
+  let leading = false;
+  let maxing = false;
+  let trailing = true;
+
+  // Bypass `requestAnimationFrame` by explicitly setting `wait=0`.
+  const useRAF = !wait && wait !== 0 &&
+    typeof root.requestAnimationFrame === "function";
+
+  if (typeof func !== "function") {
+    throw new TypeError("Expected a function");
+  }
+  wait = +wait || 0;
+  if (isObject(options)) {
+    leading = !!options.leading;
+    maxing = "maxWait" in options;
+    maxWait = maxing ? Math.max(+options.maxWait || 0, wait) : maxWait;
+    trailing = "trailing" in options ? !!options.trailing : trailing;
+  }
+
+  function invokeFunc(time) {
+    const args = lastArgs;
+    const thisArg = lastThis;
+
+    lastArgs = lastThis = undefined;
+    lastInvokeTime = time;
+    result = func.apply(thisArg, args);
+    return result;
+  }
+
+  function startTimer(pendingFunc, milliseconds) {
+    if (useRAF) {
+      root.cancelAnimationFrame(timerId);
+      return root.requestAnimationFrame(pendingFunc);
+    }
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval
+    return setTimeout(pendingFunc, milliseconds);
+  }
+
+  function cancelTimer(id) {
+    if (useRAF) {
+      root.cancelAnimationFrame(id);
+      return;
+    }
+    clearTimeout(id);
+  }
+
+  function leadingEdge(time) {
+    // Reset any `maxWait` timer.
+    lastInvokeTime = time;
+    // Start the timer for the trailing edge.
+    timerId = startTimer(timerExpired, wait);
+    // Invoke the leading edge.
+    return leading ? invokeFunc(time) : result;
+  }
+
+  function remainingWait(time) {
+    const timeSinceLastCall = time - lastCallTime;
+    const timeSinceLastInvoke = time - lastInvokeTime;
+    const timeWaiting = wait - timeSinceLastCall;
+
+    return maxing
+      ? Math.min(timeWaiting, maxWait - timeSinceLastInvoke)
+      : timeWaiting;
+  }
+
+  function shouldInvoke(time) {
+    const timeSinceLastCall = time - lastCallTime;
+    const timeSinceLastInvoke = time - lastInvokeTime;
+
+    // Either this is the first call, activity has stopped and we're at the
+    // trailing edge, the system time has gone backwards and we're treating
+    // it as the trailing edge, or we've hit the `maxWait` limit.
+    return (
+      lastCallTime === undefined ||
+      timeSinceLastCall >= wait ||
+      timeSinceLastCall < 0 ||
+      (maxing && timeSinceLastInvoke >= maxWait)
+    );
+  }
+
+  function timerExpired() {
+    const time = Date.now();
+    if (shouldInvoke(time)) {
+      return trailingEdge(time);
+    }
+    // Restart the timer.
+    timerId = startTimer(timerExpired, remainingWait(time));
+    return undefined;
+  }
+
+  function trailingEdge(time) {
+    timerId = undefined;
+
+    // Only invoke if we have `lastArgs` which means `func` has been
+    // debounced at least once.
+    if (trailing && lastArgs) {
+      return invokeFunc(time);
+    }
+    lastArgs = lastThis = undefined;
+    return result;
+  }
+
+  function cancel() {
+    if (timerId !== undefined) {
+      cancelTimer(timerId);
+    }
+    lastInvokeTime = 0;
+    lastArgs =
+      lastCallTime =
+      lastThis =
+      timerId =
+        undefined;
+  }
+
+  function flush() {
+    return timerId === undefined ? result : trailingEdge(Date.now());
+  }
+
+  function pending() {
+    return timerId !== undefined;
+  }
+
+  function debounced(...args) {
+    const time = Date.now();
+    const isInvoking = shouldInvoke(time);
+
+    lastArgs = args;
+    lastThis = this;
+    lastCallTime = time;
+
+    if (isInvoking) {
+      if (timerId === undefined) {
+        return leadingEdge(lastCallTime);
+      }
+      if (maxing) {
+        // Handle invocations in a tight loop.
+        timerId = startTimer(timerExpired, wait);
+        return invokeFunc(lastCallTime);
+      }
+    }
+    if (timerId === undefined) {
+      timerId = startTimer(timerExpired, wait);
+    }
+    return result;
+  }
+  debounced.cancel = cancel;
+  debounced.flush = flush;
+  debounced.pending = pending;
+  return debounced;
+}
+
+/**
+ * Creates a throttled function that only invokes `func` at most once per
+ * every `wait` milliseconds (or once per browser frame). The throttled function
+ * comes with a `cancel` method to cancel delayed `func` invocations and a
+ * `flush` method to immediately invoke them. Provide `options` to indicate
+ * whether `func` should be invoked on the leading and/or trailing edge of the
+ * `wait` timeout. The `func` is invoked with the last arguments provided to the
+ * throttled function. Subsequent calls to the throttled function return the
+ * result of the last `func` invocation.
+ *
+ * **Note:** If `leading` and `trailing` options are `true`, `func` is
+ * invoked on the trailing edge of the timeout only if the throttled function
+ * is invoked more than once during the `wait` timeout.
+ *
+ * If `wait` is `0` and `leading` is `false`, `func` invocation is deferred
+ * until the next tick, similar to `setTimeout` with a timeout of `0`.
+ *
+ * If `wait` is omitted in an environment with `requestAnimationFrame`, `func`
+ * invocation will be deferred until the next frame is drawn (typically about
+ * 16ms).
+ *
+ * See [David Corbacho's article](https://css-tricks.com/debouncing-throttling-explained-examples/)
+ * for details over the differences between `throttle` and `debounce`.
+ *
+ * @since 0.1.0
+ * @category Function
+ * @param {Function} func The function to throttle.
+ * @param {number} [wait=0]
+ *  The number of milliseconds to throttle invocations to; if omitted,
+ *  `requestAnimationFrame` is used (if available).
+ * @param {Object} [options={}] The options object.
+ * @param {boolean} [options.leading=true]
+ *  Specify invoking on the leading edge of the timeout.
+ * @param {boolean} [options.trailing=true]
+ *  Specify invoking on the trailing edge of the timeout.
+ * @returns {Function} Returns the new throttled function.
+ * @example
+ *
+ * // Avoid excessively updating the position while scrolling.
+ * jQuery(window).on('scroll', throttle(updatePosition, 100))
+ *
+ * // Invoke `renewToken` when the click event is fired, but not more than once every 5 minutes.
+ * const throttled = throttle(renewToken, 300000, { 'trailing': false })
+ * jQuery(element).on('click', throttled)
+ *
+ * // Cancel the trailing throttled invocation.
+ * jQuery(window).on('popstate', throttled.cancel)
+ */
+export function throttle(func, wait, options) {
+  let leading = true;
+  let trailing = true;
+
+  if (typeof func !== "function") {
+    throw new TypeError("Expected a function");
+  }
+  if (isObject(options)) {
+    leading = "leading" in options ? !!options.leading : leading;
+    trailing = "trailing" in options ? !!options.trailing : trailing;
+  }
+  return debounce(func, wait, {
+    leading,
+    trailing,
+    maxWait: wait,
+  });
+}

--- a/src/waveform.ts
+++ b/src/waveform.ts
@@ -280,7 +280,7 @@ export class APPeaksGenerator extends GObject.Object {
 
   generate_peaks_async(uri: string): void {
     const pipeline = Gst.parse_launch(
-      "uridecodebin name=uridecodebin ! audioconvert ! audio/x-raw,channels=1 ! level name=level ! fakesink name=faked",
+      "uridecodebin name=uridecodebin ! audioconvert ! audio/x-raw,channels=1 ! audioresample ! audioloudnorm ! level name=level ! fakesink name=faked",
     ) as Gst.Bin;
 
     const fakesink = pipeline.get_by_name("faked");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
       "ES2020",
     ],
     "allowJs": true,
-    "checkJs": true,
+    "checkJs": false,
     "outDir": "_build/tsc-out",
     "strict": true,
     "moduleResolution": "node",


### PR DESCRIPTION
using a new rust gstreamer plugin called audioresample

Screenshots of before and after.

Before

![image](https://github.com/vixalien/decibels/assets/37999241/307ce0cf-3eeb-43a3-b92b-bd5ad190a248)

After

![image](https://github.com/vixalien/decibels/assets/37999241/532f5194-272c-4cb5-9385-2eac1e813ccc)

The main issue is that the waveform generation takes longer now and may be more CPU-intensive.

fix #26

I invite you to test this PR.