### PR TITLE
use RMS to generate waveform

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -271,16 +271,6 @@ export class APMediaStream extends Gtk.MediaStream {
           );
           return;
       }
-
-      // try to generate an initial peaks array
-      if (this.peaks_generator.peaks.length === 0) {
-        const duration = info.get_duration();
-        if (duration > 0) {
-          this.peaks_generator.peaks = new Array(
-            Math.ceil(duration / APPeaksGenerator.INTERVAL),
-          ).fill(0);
-        }
-      }
     });
 
     this.peaks_generator = new APPeaksGenerator();

--- a/src/waveform.ts
+++ b/src/waveform.ts
@@ -301,7 +301,7 @@ export class APPeaksGenerator extends GObject.Object {
           const s = message.get_structure();
           if (s && s.has_name("level")) {
             const peakVal = s.get_value(
-              "peak",
+              "rms",
             ) as unknown as GObject.ValueArray;
 
             if (peakVal) {


### PR DESCRIPTION
This PR allows Decibels to use RMS instead of peaks to generate the waveform. This is like how Audacity does it.

fix #26 
superseds #29 