### PR TITLE
Add basic keyboard controls

### DIFF
--- a/build-aux/flatpak/com.vixalien.decibels.json
+++ b/build-aux/flatpak/com.vixalien.decibels.json
@@ -1,55 +1,56 @@
 {
-  "id": "com.vixalien.decibelsDevel",
-  "runtime": "org.gnome.Platform",
-  "runtime-version": "master",
-  "sdk": "org.gnome.Sdk",
-  "sdk-extensions": [
-    "org.freedesktop.Sdk.Extension.node18",
-    "org.freedesktop.Sdk.Extension.typescript"
-  ],
-  "tags": [
-    "nightly"
-  ],
-  "build-options": {
-    "append-path": "/usr/lib/sdk/node18/bin:/usr/lib/sdk/typescript/bin"
-  },
-  "command": "com.vixalien.decibelsDevel",
-  "finish-args": [
-    "--device=dri",
-    "--filesystem=xdg-download:ro",
-    "--filesystem=xdg-music:ro",
-    "--share=ipc",
-    "--socket=fallback-x11",
-    "--socket=wayland",
-    "--socket=pulseaudio",
-    "--env=GJS_DISABLE_JIT=1",
-    "--own-name=org.mpris.MediaPlayer2.Decibels"
-  ],
-  "cleanup": [
-    "/include",
-    "/lib/pkgconfig",
-    "/man",
-    "/share/doc",
-    "/share/gtk-doc",
-    "/share/man",
-    "/share/pkgconfig",
-    "*.la",
-    "*.a"
-  ],
-  "modules": [
-    {
-      "name": "decibels",
-      "buildsystem": "meson",
-      "config-opts": [
-        "-Dprofile=development"
-      ],
-      "sources": [
+    "id" : "com.vixalien.decibelsDevel",
+    "runtime" : "org.gnome.Platform",
+    "runtime-version" : "45",
+    "sdk" : "org.gnome.Sdk",
+    "sdk-extensions" : [
+        "org.freedesktop.Sdk.Extension.node18",
+        "org.freedesktop.Sdk.Extension.typescript"
+    ],
+    "tags" : [
+        "nightly"
+    ],
+    "build-options" : {
+        "append-path" : "/usr/lib/sdk/node18/bin:/usr/lib/sdk/typescript/bin",
+        "env" : {        }
+    },
+    "command" : "com.vixalien.decibelsDevel",
+    "finish-args" : [
+        "--device=dri",
+        "--filesystem=xdg-download:ro",
+        "--filesystem=xdg-music:ro",
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--socket=pulseaudio",
+        "--env=GJS_DISABLE_JIT=1",
+        "--own-name=org.mpris.MediaPlayer2.Decibels"
+    ],
+    "cleanup" : [
+        "/include",
+        "/lib/pkgconfig",
+        "/man",
+        "/share/doc",
+        "/share/gtk-doc",
+        "/share/man",
+        "/share/pkgconfig",
+        "*.la",
+        "*.a"
+    ],
+    "modules" : [
         {
-          "type": "git",
-          "url": "../..",
-          "branch": "HEAD"
+            "name" : "decibels",
+            "buildsystem" : "meson",
+            "config-opts" : [
+                "-Dprofile=development"
+            ],
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "../..",
+                    "branch" : "HEAD"
+                }
+            ]
         }
-      ]
-    }
-  ]
+    ]
 }

--- a/build-aux/flatpak/com.vixalien.decibels.json
+++ b/build-aux/flatpak/com.vixalien.decibels.json
@@ -1,55 +1,55 @@
 {
-    "id": "com.vixalien.decibelsDevel",
-    "runtime": "org.gnome.Platform",
-    "runtime-version": "master",
-    "sdk": "org.gnome.Sdk",
-    "sdk-extensions": [
-      "org.freedesktop.Sdk.Extension.node18",
-      "org.freedesktop.Sdk.Extension.typescript"
-    ],
-    "tags": [
-      "nightly"
-    ],
-    "build-options": {
-      "append-path": "/usr/lib/sdk/node18/bin:/usr/lib/sdk/typescript/bin"
-    },
-    "command": "com.vixalien.decibelsDevel",
-    "finish-args": [
-      "--device=dri",
-      "--filesystem=xdg-download:ro",
-      "--filesystem=xdg-music:ro",
-      "--share=ipc",
-      "--socket=fallback-x11",
-      "--socket=wayland",
-      "--socket=pulseaudio",
-      "--env=GJS_DISABLE_JIT=1",
-      "--own-name=org.mpris.MediaPlayer2.Decibels"
-    ],
-    "cleanup": [
-      "/include",
-      "/lib/pkgconfig",
-      "/man",
-      "/share/doc",
-      "/share/gtk-doc",
-      "/share/man",
-      "/share/pkgconfig",
-      "*.la",
-      "*.a"
-    ],
-    "modules": [
-      {
-        "name": "decibels",
-        "buildsystem": "meson",
-        "config-opts": [
-          "-Dprofile=development"
-        ],
-        "sources": [
-          {
-            "type": "git",
-            "url": "../..",
-            "branch": "HEAD"
-          }
-        ]
-      }
-    ]
-  }
+  "id": "com.vixalien.decibelsDevel",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "master",
+  "sdk": "org.gnome.Sdk",
+  "sdk-extensions": [
+    "org.freedesktop.Sdk.Extension.node18",
+    "org.freedesktop.Sdk.Extension.typescript"
+  ],
+  "tags": [
+    "nightly"
+  ],
+  "build-options": {
+    "append-path": "/usr/lib/sdk/node18/bin:/usr/lib/sdk/typescript/bin"
+  },
+  "command": "com.vixalien.decibelsDevel",
+  "finish-args": [
+    "--device=dri",
+    "--filesystem=xdg-download:ro",
+    "--filesystem=xdg-music:ro",
+    "--share=ipc",
+    "--socket=fallback-x11",
+    "--socket=wayland",
+    "--socket=pulseaudio",
+    "--env=GJS_DISABLE_JIT=1",
+    "--own-name=org.mpris.MediaPlayer2.Decibels"
+  ],
+  "cleanup": [
+    "/include",
+    "/lib/pkgconfig",
+    "/man",
+    "/share/doc",
+    "/share/gtk-doc",
+    "/share/man",
+    "/share/pkgconfig",
+    "*.la",
+    "*.a"
+  ],
+  "modules": [
+    {
+      "name": "decibels",
+      "buildsystem": "meson",
+      "config-opts": [
+        "-Dprofile=development"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "../..",
+          "branch": "HEAD"
+        }
+      ]
+    }
+  ]
+}

--- a/build-aux/flatpak/com.vixalien.decibels.json
+++ b/build-aux/flatpak/com.vixalien.decibels.json
@@ -1,56 +1,55 @@
 {
-    "id" : "com.vixalien.decibelsDevel",
-    "runtime" : "org.gnome.Platform",
-    "runtime-version" : "45",
-    "sdk" : "org.gnome.Sdk",
-    "sdk-extensions" : [
-        "org.freedesktop.Sdk.Extension.node18",
-        "org.freedesktop.Sdk.Extension.typescript"
+    "id": "com.vixalien.decibelsDevel",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "master",
+    "sdk": "org.gnome.Sdk",
+    "sdk-extensions": [
+      "org.freedesktop.Sdk.Extension.node18",
+      "org.freedesktop.Sdk.Extension.typescript"
     ],
-    "tags" : [
-        "nightly"
+    "tags": [
+      "nightly"
     ],
-    "build-options" : {
-        "append-path" : "/usr/lib/sdk/node18/bin:/usr/lib/sdk/typescript/bin",
-        "env" : {        }
+    "build-options": {
+      "append-path": "/usr/lib/sdk/node18/bin:/usr/lib/sdk/typescript/bin"
     },
-    "command" : "com.vixalien.decibelsDevel",
-    "finish-args" : [
-        "--device=dri",
-        "--filesystem=xdg-download:ro",
-        "--filesystem=xdg-music:ro",
-        "--share=ipc",
-        "--socket=fallback-x11",
-        "--socket=wayland",
-        "--socket=pulseaudio",
-        "--env=GJS_DISABLE_JIT=1",
-        "--own-name=org.mpris.MediaPlayer2.Decibels"
+    "command": "com.vixalien.decibelsDevel",
+    "finish-args": [
+      "--device=dri",
+      "--filesystem=xdg-download:ro",
+      "--filesystem=xdg-music:ro",
+      "--share=ipc",
+      "--socket=fallback-x11",
+      "--socket=wayland",
+      "--socket=pulseaudio",
+      "--env=GJS_DISABLE_JIT=1",
+      "--own-name=org.mpris.MediaPlayer2.Decibels"
     ],
-    "cleanup" : [
-        "/include",
-        "/lib/pkgconfig",
-        "/man",
-        "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
-        "*.la",
-        "*.a"
+    "cleanup": [
+      "/include",
+      "/lib/pkgconfig",
+      "/man",
+      "/share/doc",
+      "/share/gtk-doc",
+      "/share/man",
+      "/share/pkgconfig",
+      "*.la",
+      "*.a"
     ],
-    "modules" : [
-        {
-            "name" : "decibels",
-            "buildsystem" : "meson",
-            "config-opts" : [
-                "-Dprofile=development"
-            ],
-            "sources" : [
-                {
-                    "type" : "git",
-                    "url" : "../..",
-                    "branch" : "HEAD"
-                }
-            ]
-        }
+    "modules": [
+      {
+        "name": "decibels",
+        "buildsystem": "meson",
+        "config-opts": [
+          "-Dprofile=development"
+        ],
+        "sources": [
+          {
+            "type": "git",
+            "url": "../..",
+            "branch": "HEAD"
+          }
+        ]
+      }
     ]
-}
+  }

--- a/data/gtk/help-overlay.ui
+++ b/data/gtk/help-overlay.ui
@@ -32,6 +32,18 @@
                 <property name="action-name">win.open-file</property>
               </object>
             </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes" context="shortcut window">Pause/Play</property>
+                <property name="accelerator">space</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes" context="shortcut window">Jump 10 seconds forwards/backwards</property>
+                <property name="accelerator">Left Right</property>
+              </object>
+            </child>
           </object>
         </child>
       </object>

--- a/data/gtk/help-overlay.ui
+++ b/data/gtk/help-overlay.ui
@@ -40,8 +40,14 @@
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" translatable="yes" context="shortcut window">Jump 10 seconds forwards/backwards</property>
-                <property name="accelerator">Left Right</property>
+                <property name="title" translatable="yes" context="shortcut window">Go back 10 seconds</property>
+                <property name="accelerator">Left</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes" context="shortcut window">Go forward 10 seconds</property>
+                <property name="accelerator">Right</property>
               </object>
             </child>
           </object>

--- a/data/player.ui
+++ b/data/player.ui
@@ -40,7 +40,6 @@
                 <property name="margin-start">6</property>
                 <property name="margin-end">6</property>
                 <property name="hexpand">true</property>
-                <property name="focusable">false</property>
                 <signal name="change-value" handler="scale_change_value_cb" />
                 <property name="adjustment">
                   <object class="GtkAdjustment" id="scale_adjustment">
@@ -108,7 +107,6 @@
                     <property name="icon-name">skip-backwards-10-symbolic</property>
                     <property name="valign">3</property>
                     <property name="tooltip-text" translatable="yes">Skip back 10s</property>
-                    <property name="focusable">false</property>
                     <style>
                       <class name="circular" />
                     </style>
@@ -117,7 +115,6 @@
                 <child>
                   <object class="GtkButton" id="playback_button">
                     <property name="action-name">player.play-pause</property>
-                    <property name="focusable">false</property>
                     <child>
                       <object class="GtkImage" id="playback_image">
                         <property name="icon-name">media-playback-pause-symbolic</property>
@@ -138,7 +135,6 @@
                     <property name="icon-name">skip-forward-10-symbolic</property>
                     <property name="valign">3</property>
                     <property name="tooltip-text" translatable="yes">Skip forward 10s</property>
-                    <property name="focusable">false</property>
                     <style>
                       <class name="circular" />
                     </style>

--- a/data/player.ui
+++ b/data/player.ui
@@ -23,11 +23,6 @@
                     <signal name="scroll" handler="event_scroll"/>
                   </object>
                 </child>
-                <child>
-                  <object class="GtkEventControllerKey">
-                    <signal name="key_pressed" handler="event_key_pressed"/>
-                  </object>
-                </child>
               </object>
             </child>
           </object>
@@ -161,6 +156,11 @@
             <property name='arguments'>10</property>
           </object>
         </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkEventControllerKey">
+        <signal name="key_pressed" handler="event_key_pressed"/>
       </object>
     </child>
   </template>

--- a/data/player.ui
+++ b/data/player.ui
@@ -16,7 +16,6 @@
               <object class="APWaveForm" id="waveform">
                 <signal name="position-changed" handler="waveform_position_changed_cb" />
                 <property name="vexpand">true</property>
-                <property name="focusable">true</property>
                 <child>
                   <object class="GtkEventControllerScroll">
                     <property name="flags">both-axes</property>

--- a/data/player.ui
+++ b/data/player.ui
@@ -16,10 +16,16 @@
               <object class="APWaveForm" id="waveform">
                 <signal name="position-changed" handler="waveform_position_changed_cb" />
                 <property name="vexpand">true</property>
+                <property name="focusable">true</property>
                 <child>
                   <object class="GtkEventControllerScroll">
                     <property name="flags">horizontal</property>
                     <signal name="scroll" handler="event_scroll"/>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkEventControllerKey">
+                    <signal name="key_pressed" handler="event_key_pressed"/>
                   </object>
                 </child>
               </object>
@@ -34,6 +40,7 @@
                 <property name="margin-start">6</property>
                 <property name="margin-end">6</property>
                 <property name="hexpand">true</property>
+                <property name="focusable">false</property>
                 <signal name="change-value" handler="scale_change_value_cb" />
                 <property name="adjustment">
                   <object class="GtkAdjustment" id="scale_adjustment">
@@ -101,6 +108,7 @@
                     <property name="icon-name">skip-backwards-10-symbolic</property>
                     <property name="valign">3</property>
                     <property name="tooltip-text" translatable="yes">Skip back 10s</property>
+                    <property name="focusable">false</property>
                     <style>
                       <class name="circular" />
                     </style>
@@ -109,6 +117,7 @@
                 <child>
                   <object class="GtkButton" id="playback_button">
                     <property name="action-name">player.play-pause</property>
+                    <property name="focusable">false</property>
                     <child>
                       <object class="GtkImage" id="playback_image">
                         <property name="icon-name">media-playback-pause-symbolic</property>
@@ -129,6 +138,7 @@
                     <property name="icon-name">skip-forward-10-symbolic</property>
                     <property name="valign">3</property>
                     <property name="tooltip-text" translatable="yes">Skip forward 10s</property>
+                    <property name="focusable">false</property>
                     <style>
                       <class name="circular" />
                     </style>

--- a/src/player.ts
+++ b/src/player.ts
@@ -231,11 +231,9 @@ export class APPlayerState extends Adw.Bin {
     if (keyval === Gdk.KEY_space) {
       stream.playing ? stream.pause() : stream.play();
     } else if (keyval === Gdk.KEY_Left) {
-      const d = Math.max(Math.min(stream.timestamp - 10000000, stream.duration), 0);
-      stream.seek(d);
+      stream.skip_seconds(-10);
     } else if (keyval === Gdk.KEY_Right) {
-      const d = Math.max(Math.min(stream.timestamp + 10000000, stream.duration), 0);
-      stream.seek(d);
+      stream.skip_seconds(10);
     } else {
       return Gdk.EVENT_PROPAGATE;
     }

--- a/src/player.ts
+++ b/src/player.ts
@@ -1,6 +1,7 @@
 import Adw from "gi://Adw";
 import Gtk from "gi://Gtk?version=4.0";
 import GObject from "gi://GObject";
+import Gdk from "gi://Gdk?version=4.0"
 
 import { Window } from "./window.js";
 import { APHeaderBar } from "./header.js";
@@ -214,6 +215,32 @@ export class APPlayerState extends Adw.Bin {
     const d = Math.max(Math.min(stream.timestamp - delta, stream.duration), 0);
 
     stream.seek(d);
+  }
+
+  private event_key_pressed(
+    _controller: Gtk.EventControllerKey,
+    keyval: number,
+    _keycode: number,
+    _modifier: Gdk.ModifierType
+  ): boolean {
+    const window = this.get_root() as Window;
+    const stream = window?.stream;
+
+    if (!stream) return Gdk.EVENT_PROPAGATE;
+
+    if (keyval === Gdk.KEY_space) {
+      stream.playing ? stream.pause() : stream.play();
+    } else if (keyval === Gdk.KEY_Left) {
+      const d = Math.max(Math.min(stream.timestamp - 10000000, stream.duration), 0);
+      stream.seek(d);
+    } else if (keyval === Gdk.KEY_Right) {
+      const d = Math.max(Math.min(stream.timestamp + 10000000, stream.duration), 0);
+      stream.seek(d);
+    } else {
+      return Gdk.EVENT_PROPAGATE;
+    }
+
+    return Gdk.EVENT_PROPAGATE;
   }
 
   private waveform_position_changed_cb(_scale: Gtk.Scale, value: number) {

--- a/src/player.ts
+++ b/src/player.ts
@@ -240,7 +240,7 @@ export class APPlayerState extends Adw.Bin {
       return Gdk.EVENT_PROPAGATE;
     }
 
-    return Gdk.EVENT_PROPAGATE;
+    return Gdk.EVENT_STOP;
   }
 
   private waveform_position_changed_cb(_scale: Gtk.Scale, value: number) {


### PR DESCRIPTION
This PR adds keyboard controls on the waveform element, which is focused by default.
This means that one can now simply navigate the song with the keyboard without first tab-ing to the GtkScale.

New keyboard controls:
- Press space to pause/play
- Press arrow_left/arrow_right to jump backwards/forwards 10 seconds

These controls have been added to the help page.
Translations for these keys probably need to be added, but I have no idea how to do that.

More precise controls could be added in the future, but I wanted to keep this PR small.

The GtkScale and the three buttons in the lower middle (back 10s, pause, skip 10s) are now not focusable anymore because this should be way more intuitive.