### PR TITLE
appdata: Improve appdata for AppStream 1.0

### DIFF
--- a/build-aux/flatpak/com.vixalien.decibels.json
+++ b/build-aux/flatpak/com.vixalien.decibels.json
@@ -40,6 +40,7 @@
     {
       "name": "decibels",
       "buildsystem": "meson",
+      "run-tests": true,
       "config-opts": [
         "-Dprofile=development"
       ],

--- a/data/com.vixalien.decibels.metainfo.xml.in.in
+++ b/data/com.vixalien.decibels.metainfo.xml.in.in
@@ -6,7 +6,11 @@
   <summary>Play audio files</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0</project_license>
+  <!-- developer_name tag deprecated with Appstream 1.0 -->
   <developer_name translatable="no">Angelo Verlain</developer_name>
+  <developer id="github.com">
+    <name translatable="no">Angelo Verlain</name>
+  </developer>
   <update_contact>hey@vixalien.com</update_contact>
   <description>
     <p>Current features:</p>

--- a/data/meson.build
+++ b/data/meson.build
@@ -35,9 +35,14 @@ appstream_file = i18n.merge_file(
   install_dir: decibels_datadir / 'metainfo'
 )
 
-appstream_util = find_program('appstream-util', required: false)
-if appstream_util.found()
-  test('Validate appstream file', appstream_util, args: ['validate', '--nonet', appstream_file])
+# Validate Appdata
+appstreamcli = find_program('appstreamcli', required: false)
+if (appstreamcli.found())
+  test('Validate appdata file',
+    appstreamcli,
+    args: ['validate', '--no-net', '--explain', appstream_file],
+    workdir: meson.current_build_dir()
+  )
 endif
 
 gsettings_conf = configuration_data()


### PR DESCRIPTION
- Add the `<developer><name>` tag
- Mark the `<developer_name>` tag as deprecated
- Use appstreamcli to validate appdata