### PR TITLE
Fix programming language in DOAP file

### DIFF
--- a/decibels.doap
+++ b/decibels.doap
@@ -9,7 +9,7 @@
   <homepage rdf:resource="https://github.com/vixalien/decibels/" />
   <bug-database rdf:resource="https://github.com/vixalien/decibels/issues/"/>
 
-  <programming-language>Rust</programming-language>
+  <programming-language>JavaScript</programming-language>
   <platform>GTK 4</platform>
   <platform>Libadwaita</platform>
 


### PR DESCRIPTION
It was set to Rust, and showed up incorrectly on the w.g.o web page.